### PR TITLE
Create better area ids

### DIFF
--- a/adr_dhis2_geodata_etl.py
+++ b/adr_dhis2_geodata_etl.py
@@ -207,28 +207,17 @@ def sort_by_admin_level(df: pd.DataFrame) -> pd.DataFrame:
     return df.sort_values(by='admin_level').reset_index()
 
 
-<<<<<<< HEAD
-def save_location_hierarchy(df:pd.DataFrame) -> pd.DataFrame:
+def save_location_hierarchy(df: pd.DataFrame) -> pd.DataFrame:
     lh_df = df[df['admin_level'] <= AREAS_ADMIN_LEVEL][['id', 'name', 'admin_level', 'parent_id', 'sort_order']]
     lh_df.columns = ['area_id', 'area_name', 'area_level', 'parent_area_id', 'sort_order']
-=======
-def save_location_hierarchy(df: pd.DataFrame) -> pd.DataFrame:
-    lh_df = df[df['admin_level'] <= AREAS_ADMIN_LEVEL][['id', 'name', 'admin_level', 'parent_id', 'sort_order', 'dhis2_id']]
-    lh_df.columns = ['area_id', 'area_name', 'area_level', 'parent_area_id', 'sort_order', 'dhis2_id']
->>>>>>> Some PEP8 changes.
     if not os.path.exists(OUTPUT_DIR_NAME):
         os.makedirs(OUTPUT_DIR_NAME)
     lh_df.to_csv(f"{OUTPUT_DIR_NAME}/location_hierarchy.csv", index=False)
     return df
 
 
-<<<<<<< HEAD
-def save_facilities_list(df:pd.DataFrame) -> pd.DataFrame:
-    fl_df = df[df['admin_level'] > AREAS_ADMIN_LEVEL].reindex(columns=['id', 'name', 'parent_id', 'lat', 'long', 'type', 'sort_order'])
-=======
 def save_facilities_list(df: pd.DataFrame) -> pd.DataFrame:
-    fl_df = df[df['admin_level'] > AREAS_ADMIN_LEVEL].reindex(columns=['id', 'name', 'parent_id', 'lat', 'long', 'type', 'sort_order', 'dhis2_id'])
->>>>>>> Some PEP8 changes.
+    fl_df = df[df['admin_level'] > AREAS_ADMIN_LEVEL].reindex(columns=['id', 'name', 'parent_id', 'lat', 'long', 'type', 'sort_order'])
     fl_df['type'] = 'health facility'
     fl_df.columns = ['facility_id', 'facility_name', 'parent_area_id', 'lat', 'long', 'type', 'sort_order']
     if not os.path.exists(OUTPUT_DIR_NAME):
@@ -237,8 +226,7 @@ def save_facilities_list(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-<<<<<<< HEAD
-def save_dhis2_ids(df:pd.DataFrame) -> pd.DataFrame:
+def save_dhis2_ids(df: pd.DataFrame) -> pd.DataFrame:
     dhis2_ids = df[['id', 'dhis2_id']]
     if not os.path.exists(OUTPUT_DIR_NAME):
         os.makedirs(OUTPUT_DIR_NAME)
@@ -246,10 +234,7 @@ def save_dhis2_ids(df:pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def save_ids_mapping(df:pd.DataFrame) -> pd.DataFrame:
-=======
 def save_ids_mapping(df: pd.DataFrame) -> pd.DataFrame:
->>>>>>> Some PEP8 changes.
     fl_df = df.reindex(columns=['id', 'dhis2_id'])
     fl_df['pepfar_id'] = ''
     fl_df.columns = ["area_id", "dhis2_id", "pepfar_id"]


### PR DESCRIPTION
This PR creates area ids of the form: 
`[iso][-][admin 1 id][-][admin 2 id][-][admin 3 id]`
e.g. zam-2-34, zam-11 and zam

Points to note:
- Takes the iso code from the output file name. 
- The algorithm does two complete passes over the data and is made up of three main steps:
  1. Passes over all data and groups all the dhis2 ids in the path under admin levels.
  2. Assigns incremental numeric ids to each dhis2 id within each admin level group.
  3. Passes over all the data and uses the incremental ids to build an ID of the form above. 
- I use map functions instead of for loops to significantly speed up the code. Though I'm aware they're not as readable. Is there a better way of presenting them?
- Solution works but there is probably a more efficient way of doing it.  Don't know whether it's worth finding though.

Let's discuss tomorrow. 

[Here](https://docs.google.com/document/d/1x8hJWRUfmFxrzLpPUTxnVLNDr4jLsczve9YlUCJhYMI/edit?usp=sharing) are some thoughts on the different ID types: 